### PR TITLE
수동 패치 감지 로직 추가

### DIFF
--- a/patchers/windows/patcher.txt
+++ b/patchers/windows/patcher.txt
@@ -99,8 +99,12 @@ function Copy-WithBackup {
     Write-Output "$trimmedSource >>> $destination"
 }
 
-$bg3Path = getSteamBG3Path
+function cleanExit {
+	Remove-Item -Path patcher.ps1
+	exit
+}
 
+$bg3Path = getSteamBG3Path
 if ($bg3Path) {
 	Write-Output "Baldurs Gate 3 Path (Steam): $bg3Path"
 } else {
@@ -110,14 +114,17 @@ if ($bg3Path) {
 		Write-Output "Baldurs Gate 3 Path (User): $bg3Path"
 	} else {
 		Write-Output "Patch cancelled."
-		Remove-Item -Path patcher.ps1
-		exit
+		cleanExit
 	}
 }
 
 if ($bg3Path) {
     $sourceData = Join-Path $PSScriptRoot "Data"
     $destinationData = Join-Path $bg3Path "Data"
+	if($sourceData -eq $destinationData) {
+		Write-Host "Patch is already complete (Running patcher in game path)" -ForegroundColor Red
+		cleanExit
+	}
     if (Test-Path $sourceData) {
         Get-ChildItem -Path $sourceData -Recurse | ForEach-Object {
             $relativePath = $_.FullName.Substring($sourceData.Length)
@@ -130,9 +137,9 @@ if ($bg3Path) {
                 Copy-WithBackup -Source $_.FullName -Destination $destinationPath
             }
         }
-        Write-Host "Korean Patch Done!" -ForegroundColor Green
+        Write-Host "Korean patch done! Balkkiyathou~!!!" -ForegroundColor Green
     } else {
-        Write-Error "Cannot Find Patchfile Please Uncompress file first."
+        Write-Error "Cannot find patch file. Please uncompress file first."
     }
 }
-Remove-Item -Path patcher.ps1
+cleanExit


### PR DESCRIPTION
기존의 수동 패치 방법을 진행한 뒤 (배포된 압축 파일 내부 파일을 직접 게임 폴더에 전부 붙여넣기)

이미 수동으로 패치가 되었음에도 불구하고

게임 폴더에서 패쳐를 한번 더 실행하는 경우가 많아 (이 경우 패치 로직이 정상 작동하지 않아 리소스가 `Not Found`로 불러와지는 등의 오류가 생깁니다)

![image](https://github.com/StableFluffy/bg3_paks/assets/58779799/11e8313b-c6ca-4ec5-a801-905db8bfc1fe)
![image](https://github.com/StableFluffy/bg3_paks/assets/58779799/13533f16-ba4e-4611-a472-5e9bcb38660c)

해당 케이스의 작동을 막기 위해, 설치 대상 경로와, 현재 스크립트 경로가 같은 경우 패치 로직을 실행하지 않고 종료하는 로직을 추가합니다.

